### PR TITLE
GoalPreview: GoalEditModal reopens automatically

### DIFF
--- a/src/components/GoalPreview/GoalPreview.tsx
+++ b/src/components/GoalPreview/GoalPreview.tsx
@@ -121,6 +121,10 @@ const GoalPreview: React.FC<GoalPreviewProps> = ({ preview, onClose, onDelete })
         setGoalEditModalVisible(true);
     }, []);
 
+    const onGoalEditModalClose = useCallback(() => {
+        setGoalEditModalVisible(false);
+    }, []);
+
     const updateGoal = useGoalUpdate(preview.id);
     const { reactionsProps, goalReaction, commentReaction } = useReactionsResource(goal?.reactions);
 
@@ -352,6 +356,7 @@ const GoalPreview: React.FC<GoalPreviewProps> = ({ preview, onClose, onDelete })
                             hotkeys={editGoalKeys}
                             visible={goalEditModalVisible}
                             onShow={onGoalEditModalShow}
+                            onClose={onGoalEditModalClose}
                         >
                             <GoalEditForm goal={g} onSubmit={onGoalEdit} />
                         </ModalOnEvent>


### PR DESCRIPTION
## PR includes

- [x] Bug Fix

## Related issues

Resolve #888


## QA Instructions, Screenshots, Recordings
  
* go to dashboard or project page
* select any goal which possible to edit
* open edit dialog
* close dialog
* select any other goal than select previous
* Voila! You didn't see edit dialog again.

https://github.com/taskany-inc/issues/assets/7002692/29ff5001-2da5-4e9c-be2d-a6055616ea7c
