### PR TITLE
Upsert estimate field instead of create and create history record about estimate field's change

### DIFF
--- a/prisma/migrations/20230602095919_/migration.sql
+++ b/prisma/migrations/20230602095919_/migration.sql
@@ -9,7 +9,7 @@ CREATE TABLE "EstimateToGoal" (
     "id" SERIAL NOT NULL,
     "goalId" TEXT NOT NULL,
     "estimateId" INTEGER NOT NULL,
-    "createadAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "EstimateToGoal_pkey" PRIMARY KEY ("id")
 );
@@ -31,4 +31,4 @@ ALTER TABLE "EstimateToGoal" ADD CONSTRAINT "EstimateToGoal_estimateId_fkey" FOR
 
 -- Fill join table
 INSERT INTO "EstimateToGoal" ("goalId", "estimateId", "createdAt")
-SELECT "goalId", "id", "createdAt" from "Estimate"
+SELECT "goalId", "id", "createdAt" FROM "Estimate"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,7 +168,8 @@ model EstimateToGoal {
   goalId     String
   estimate   Estimate @relation(fields: [estimateId], references: [id])
   estimateId Int
-  createadAt DateTime @default(now())
+
+  createdAt DateTime @default(now())
 
   @@index([goalId])
   @@index([estimateId])

--- a/trpc/router/goal.ts
+++ b/trpc/router/goal.ts
@@ -172,7 +172,7 @@ export const goal = router({
                             },
                         },
                         orderBy: {
-                            createadAt: 'asc',
+                            createdAt: 'asc',
                         },
                     },
                 },
@@ -277,7 +277,7 @@ export const goal = router({
                             estimate: true,
                         },
                         orderBy: {
-                            createadAt: 'asc',
+                            createdAt: 'asc',
                         },
                     },
                 },
@@ -293,7 +293,7 @@ export const goal = router({
                             estimate: true,
                         },
                         orderBy: {
-                            createadAt: 'asc',
+                            createdAt: 'asc',
                         },
                     },
                 },

--- a/trpc/router/project.ts
+++ b/trpc/router/project.ts
@@ -170,7 +170,7 @@ export const project = router({
                             estimate: true,
                         },
                         orderBy: {
-                            createadAt: 'asc',
+                            createdAt: 'asc',
                         },
                     },
                 },
@@ -201,7 +201,7 @@ export const project = router({
                             estimate: true,
                         },
                         orderBy: {
-                            createadAt: 'asc',
+                            createdAt: 'asc',
                         },
                     },
                 },


### PR DESCRIPTION
Change field name from `createadAt` to `createdAt`

## PR includes

- [x] Bug Fix

## Related issues

Related issues #985 

## QA Instructions, Screenshots, Recordings
  
Migration will applied correctly
