### PR TITLE
Disable completion in criteria weight field

### DIFF
--- a/src/components/CriteriaForm/CriteriaForm.tsx
+++ b/src/components/CriteriaForm/CriteriaForm.tsx
@@ -150,6 +150,7 @@ const WeightField = forwardRef<HTMLInputElement, WeightFieldProps>(
 
         return (
             <StyledFormInput
+                autoComplete="off"
                 name={name}
                 value={value}
                 error={error?.message != null ? error : undefined}


### PR DESCRIPTION
Now weight input haven't native autocomplete

## PR includes

- [x] Bug Fix

## Related issues

Resolve #1222 

## QA Instructions, Screenshots, Recordings
  
<img width="863" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/55117a5c-8e6b-4b01-a505-b86c14dad4ab">
