### PR TITLE
Goal create form stays busy after an error backend response

### DIFF
--- a/src/components/GoalCreateForm/GoalCreateForm.tsx
+++ b/src/components/GoalCreateForm/GoalCreateForm.tsx
@@ -107,6 +107,8 @@ const GoalCreateForm: React.FC<GoalCreateFormProps> = ({ title, onGoalCreate }) 
 
             onGoalCreate?.(res);
         }
+
+        setBusy(false);
     };
 
     return (


### PR DESCRIPTION
## PR includes
- [x] Bug Fix

## Related issues
Resolve #1230 
Related issues #1326 

## QA Instructions, Screenshots, Recordings
  
request response status 500

https://github.com/taskany-inc/issues/assets/95316053/8a28ed5b-24af-4c37-bd4e-a041e30b1822


request response status 200

https://github.com/taskany-inc/issues/assets/95316053/76c9c360-bbef-4f37-8a0e-5fb728e2cc13


I couldnt find a solution with a utility function because the whole solution comes down to await


