### PR TITLE
The average project score doesn't recalculate after moving goal into an archive

### DIFF
--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -335,7 +335,7 @@ export const updateGoalWithCalculatedWeight = async (goalId: string) => {
                 await ctx.$executeRaw`
                     UPDATE "Project"
                     SET "averageScore" = (SELECT AVG("completedCriteriaWeight") FROM "Goal"
-                        WHERE "projectId" = ${updatedGoal.projectId})
+                        WHERE "projectId" = ${updatedGoal.projectId} AND "archived" IS NOT true)
                     WHERE "id" = ${updatedGoal.projectId};
                 `;
             }

--- a/trpc/router/goal.ts
+++ b/trpc/router/goal.ts
@@ -708,7 +708,7 @@ export const goal = router({
             }
 
             try {
-                const updatedGoal = prisma.goal.update({
+                const updatedGoal = await prisma.goal.update({
                     where: { id },
                     data: {
                         archived,
@@ -722,6 +722,10 @@ export const goal = router({
                         },
                     },
                 });
+
+                if (updatedGoal) {
+                    await updateGoalWithCalculatedWeight(updatedGoal.id);
+                }
 
                 const recipients = Array.from(
                     new Set(


### PR DESCRIPTION
Now after moving goal into archive the average score will recalculate for non-archived goals

## PR includes

- [x] Bug Fix

## Related issues

Resolve #1370

## QA Instructions, Screenshots, Recordings
  
1. Create goal and criteria
2. Mark criteria as complete
3. Remove goal from the project
