### PR TITLE
Broken weight field validation in CriteriaForm

### DIFF
--- a/src/components/GoalCriteria/GoalCriteria.tsx
+++ b/src/components/GoalCriteria/GoalCriteria.tsx
@@ -321,7 +321,7 @@ export const GoalCriteria: React.FC<GoalCriteriaProps> = ({
 
     const dataForValidateCriteria = useMemo(
         () =>
-            criteriaList.reduce(
+            criteriaList.reduce<{ sum: number; title: string[] }>(
                 (acc, { weight, title }, criteriaIdx) => {
                     if (mode === 'edit' && index === criteriaIdx) {
                         return acc;
@@ -332,7 +332,7 @@ export const GoalCriteria: React.FC<GoalCriteriaProps> = ({
                 },
                 {
                     sum: 0,
-                    title: [] as string[],
+                    title: [],
                 },
             ),
         [criteriaList, mode, index],
@@ -405,7 +405,7 @@ export const GoalCriteria: React.FC<GoalCriteriaProps> = ({
                                         goalId,
                                         goalAsGriteria:
                                             item.goalIdAsCriteria != null ? { id: item.goalIdAsCriteria } : undefined,
-                                        weight: String(item.weight),
+                                        weight: item.weight ? String(item.weight) : '',
                                     }}
                                     onSubmit={onUpdateCriteria}
                                     onReset={() =>


### PR DESCRIPTION
Now `weight` field validation works correctly
Passed value will be checks by validation function
If value is empty then validating process doesn't runs
## PR includes

- [x] Bug Fix

## Related issues

Resolve #1437 

## QA Instructions, Screenshots, Recordings
  
1. Open add or edit criteria
2. Try to pass value into `weight` filed
   1. if value less or greater of available weights interval then behind of the input shows error message
   2. By clear value in an input validating message will be dismiss
