### PR TITLE
Worker is not found on docker start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN npx prisma generate
 
 EXPOSE 3000
 
-CMD ["node_modules/.bin/concurrently", "node background/utils/worker/index.js", "node server.js"]
+CMD ["node_modules/.bin/concurrently", "node background/worker/index.js", "node server.js"]

--- a/src/utils/worker/mail/templates.ts
+++ b/src/utils/worker/mail/templates.ts
@@ -1,8 +1,8 @@
 import mdit from 'markdown-it';
 
-import type { FieldDiff } from '../../../types/common';
-
 import { SendMailProps } from '.';
+
+type FieldDiff = [string | undefined | null, string | undefined | null];
 
 const md = mdit('default', {
     typographer: true,


### PR DESCRIPTION
Put back worker path + removed type import that broke the worker assembly


## PR includes

- [ x] Bug Fix

## Related issues

Resolve #1449 


