### PR TITLE
default(now) in prisma timestamps looses time zone if it's not UTC

### DIFF
--- a/prisma/migrations/20230807192046_change_default_timestamps/migration.sql
+++ b/prisma/migrations/20230807192046_change_default_timestamps/migration.sql
@@ -1,0 +1,65 @@
+-- AlterTable
+ALTER TABLE "Activity" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "Comment" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "Estimate" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "EstimateToGoal" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "Filter" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "Flow" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "Ghost" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "Goal" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "GoalAchieveCriteria" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "GoalHistory" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "Job" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "Project" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "Reaction" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "Settings" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "State" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "Tag" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "createdAt" SET DEFAULT timezone('utc', current_timestamp),
+ALTER COLUMN "updatedAt" SET DEFAULT timezone('utc', current_timestamp);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,8 +87,8 @@ model User {
   activity      Activity? @relation(fields: [activityId], references: [id])
   activityId    String?   @unique
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 }
 
 model Ghost {
@@ -98,8 +98,8 @@ model Ghost {
   hostId   String
   activity Activity?
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 
   @@index([hostId])
 }
@@ -129,8 +129,8 @@ model Activity {
   goalActions        GoalHistory[]         @relation("goalActions")
   criterion          GoalAchieveCriteria[]
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 
   @@index([ghostId])
 }
@@ -152,8 +152,8 @@ model Project {
   stargizers   Activity[] @relation("projectStargizers")
   averageScore Int?
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 }
 
 model Estimate {
@@ -166,8 +166,8 @@ model Estimate {
   activity   Activity         @relation(fields: [activityId], references: [id])
   activityId String
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 
   @@index([date])
 }
@@ -179,7 +179,7 @@ model EstimateToGoal {
   estimate   Estimate @relation(fields: [estimateId], references: [id])
   estimateId Int
 
-  createdAt DateTime @default(now())
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
 
   @@index([goalId])
   @@index([estimateId])
@@ -230,8 +230,8 @@ model Goal {
   goalAsCriteria          GoalAchieveCriteria?  @relation("GoalAsCriteria")
   completedCriteriaWeight Int?
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 
   @@unique([projectId, scopeId])
   @@index([ownerId])
@@ -248,8 +248,8 @@ model Filter {
   activityId  String
   stargizers  Activity[] @relation("filterStargizers")
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 }
 
 model Comment {
@@ -263,8 +263,8 @@ model Comment {
   stateId     String?
   reactions   Reaction[]
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 
   @@index([activityId])
   @@index([goalId])
@@ -280,8 +280,8 @@ model Reaction {
   comment    Comment? @relation(fields: [commentId], references: [id])
   commentId  String?
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 
   @@index([activityId])
   @@index([goalId])
@@ -297,8 +297,8 @@ model Flow {
   states      State[]
   recommended Boolean?
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 }
 
 model State {
@@ -311,8 +311,8 @@ model State {
   goals    Goal[]    @relation("goalState")
   comments Comment[]
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 }
 
 model Settings {
@@ -323,8 +323,8 @@ model Settings {
   flowId   String?
   activity Activity?
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 }
 
 model Tag {
@@ -336,8 +336,8 @@ model Tag {
   activity    Activity  @relation(fields: [activityId], references: [id])
   activityId  String
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 }
 
 model Job {
@@ -351,8 +351,8 @@ model Job {
   cron     String?
   error    String?
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 }
 
 model GoalHistory {
@@ -366,7 +366,7 @@ model GoalHistory {
   activity      Activity @relation("goalActions", fields: [activityId], references: [id])
   activityId    String
 
-  createdAt DateTime @default(now())
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
 
   @@index([id])
   @@index([goalId])
@@ -385,8 +385,8 @@ model GoalAchieveCriteria {
   activityId       String
   deleted          Boolean?
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @db.Timestamp()
+  updatedAt DateTime @default(dbgenerated("timezone('utc', current_timestamp)")) @updatedAt
 
   @@index([title])
   @@index([goalId])


### PR DESCRIPTION
## PR includes

- [x] Bug Fix

Use utc-based default timestamps as db stores timestamps without time zone

## Related issues

Resolve #1467 

