### PR TITLE
Subprojects count doesn't shown before open Collapsed item

### DIFF
--- a/src/components/ProjectListItemConnected.tsx
+++ b/src/components/ProjectListItemConnected.tsx
@@ -54,12 +54,15 @@ export const ProjectListItemConnected: FC<{
         setIsCollapsed((value) => !value);
     }, []);
 
-    const childrenNodeShown = childrenProjects.reduce((acum, p) => {
-        if (p._count.goals) {
-            return acum + 1;
-        }
-        return acum;
-    }, 0);
+    const childrenNodeShown =
+        status === 'success'
+            ? childrenProjects.reduce((acum, p) => {
+                  if (p._count.goals) {
+                      return acum + 1;
+                  }
+                  return acum;
+              }, 0)
+            : project.children.length;
 
     // hide projects without goals
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/taskany-inc/issues/blob/main/CONTRIBUTING.md;
     - 📖 Read the Forem Code of Conduct: https://github.com/taskany-inc/issues/blob/main/CODE_OF_CONDUCT.md;
     - 👷‍♀️ Create small PRs. in most cases this will be possible;
     - ✅ Provide tests for your changes;
     - 📝 Use conventional commit messages: https://www.conventionalcommits.org/en/v1.0.0/;
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Taskany Team member before any CI builds will run.
-->

## PR includes

- [x] Bug Fix

## Related issues

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolve #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

Resolve #1471 

## QA Instructions, Screenshots, Recordings
 
<img width="1383" alt="Снимок экрана 2023-08-08 в 12 49 41" src="https://github.com/taskany-inc/issues/assets/9020793/32875d35-ca73-4c6f-b3d7-33a7f45b3e93">

<!-- THANKS FOR YOUR CONTRIBUTION -->
