### PR TITLE
Projects page doesn't show projects with multiple children

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -65,8 +65,8 @@ if (process.env.KEYCLOAK_ID && process.env.KEYCLOAK_SECRET && process.env.KEYCLO
             clientSecret: process.env.KEYCLOAK_SECRET,
             issuer: process.env.KEYCLOAK_ISSUER,
             client: {
-                authorization_signed_response_alg: process.env.JWS_ALGORITHM || 'RS256',
-                id_token_signed_response_alg: process.env.JWS_ALGORITHM || 'RS256',
+                authorization_signed_response_alg: process.env.JWS_ALGORITHM || 'ES256',
+                id_token_signed_response_alg: process.env.JWS_ALGORITHM || 'ES256',
             },
         }),
     );

--- a/trpc/router/project.ts
+++ b/trpc/router/project.ts
@@ -315,7 +315,7 @@ export const project = router({
                         p."activityId",
                         count(distinct g) as "goalsCount"
                     from "Project" as p
-                    left join "Goal" as g on p.id = g."projectId"
+                    left join "Goal" as g on p.id = g."projectId" and g."archived" is not true
                     left join "Activity" as a on a.id = p."activityId"
                     left join "Tag" as t on g."activityId" = t."activityId"
                     left join "_projectStargizers" as ps on ps."B" = p.id
@@ -324,8 +324,8 @@ export const project = router({
                     left join "_goalWatchers" as gw on gw."B" = g.id
                     left join "_goalParticipants" as gp on gp."B" = g.id
                     left join "_parentChildren" as pc on pc."B" = p.id
-                    where g."archived" is not true
-                        ${sqlFilters} and p."archived" is not true
+                    where p."archived" is not true
+                        ${sqlFilters}
                         ${firstLevel ? Prisma.sql`and pc."A" is null` : Prisma.empty}
                     group by p.id
                     order by max(g."updatedAt") desc


### PR DESCRIPTION
## PR includes

- [x] Bug Fix

## Related issues

Resolve #1570

Moved the query out of the scope so goal filtering doesn't affect projects. Also changed default keycloak algo to match current standards.