### PR TITLE
Do not show participants block if empty and !goal._isEditable

### DIFF
--- a/src/components/GoalPage/GoalPage.tsx
+++ b/src/components/GoalPage/GoalPage.tsx
@@ -489,35 +489,37 @@ export const GoalPage = ({ user, ssrTime, params: { id } }: ExternalPageProps<{ 
                         )}
                     </IssueMeta>
 
-                    <IssueMeta title={tr('Participants')}>
-                        {goal.participants?.map(({ user }) => (
-                            <UserBadge
-                                key={user?.activityId}
-                                user={user}
-                                onCleanButtonClick={
-                                    goal._isEditable ? onGoalParticipantRemove(user?.activityId) : undefined
-                                }
-                            />
-                        ))}
-
-                        {nullable(goal._isEditable, () => (
-                            <StyledInlineInput>
-                                <UserComboBox
-                                    placement="bottom-start"
-                                    placeholder={tr('Type user name or email')}
-                                    filter={participantsFilter}
-                                    onChange={onGoalParticipantAdd}
-                                    renderTrigger={(props) => (
-                                        <StyledInlineTrigger
-                                            icon={<IconPlusCircleOutline size="xs" />}
-                                            text={tr('Add participant')}
-                                            onClick={props.onClick}
-                                        />
-                                    )}
+                    {nullable(goal._isEditable || goal.participants.length, () => (
+                        <IssueMeta title={tr('Participants')}>
+                            {goal.participants?.map(({ user }) => (
+                                <UserBadge
+                                    key={user?.activityId}
+                                    user={user}
+                                    onCleanButtonClick={
+                                        goal._isEditable ? onGoalParticipantRemove(user?.activityId) : undefined
+                                    }
                                 />
-                            </StyledInlineInput>
-                        ))}
-                    </IssueMeta>
+                            ))}
+
+                            {nullable(goal._isEditable, () => (
+                                <StyledInlineInput>
+                                    <UserComboBox
+                                        placement="bottom-start"
+                                        placeholder={tr('Type user name or email')}
+                                        filter={participantsFilter}
+                                        onChange={onGoalParticipantAdd}
+                                        renderTrigger={(props) => (
+                                            <StyledInlineTrigger
+                                                icon={<IconPlusCircleOutline size="xs" />}
+                                                text={tr('Add participant')}
+                                                onClick={props.onClick}
+                                            />
+                                        )}
+                                    />
+                                </StyledInlineInput>
+                            ))}
+                        </IssueMeta>
+                    ))}
                     {nullable(!(!goal.tags.length && !goal._isEditable), () => (
                         <>
                             <IssueMeta title={tr('Tags')}>


### PR DESCRIPTION
## PR includes
- [x] Bug Fix

## Related issues
Resolve #1761 

## QA Instructions, Screenshots, Recordings

### admin if participants block is empty
<img width="336" alt="Снимок экрана 2023-10-03 в 15 52 49" src="https://github.com/taskany-inc/issues/assets/95316053/38434921-b3bb-494b-8274-89614ea1babc">

### user if participants block is empty/non-empty
<img width="328" alt="Снимок экрана 2023-10-03 в 15 52 23" src="https://github.com/taskany-inc/issues/assets/95316053/cda619c6-74bf-4175-a6f9-d918ab2411f9">
<img width="333" alt="Снимок экрана 2023-10-03 в 15 48 34" src="https://github.com/taskany-inc/issues/assets/95316053/56f08574-e895-4d3d-8205-064e7d4b77a7">

