### PR TITLE
Dashboard not updates after goal update

### DIFF
--- a/src/components/DashboardPage/DashboardPage.tsx
+++ b/src/components/DashboardPage/DashboardPage.tsx
@@ -59,7 +59,22 @@ export const DashboardPage = ({ user, ssrTime, defaultPresetFallback }: External
 
     useFMPMetric(!!data);
 
-    const { setPreview, preview } = useGoalPreview();
+    const { setPreview, preview, on } = useGoalPreview();
+
+    useEffect(() => {
+        const unsubUpdate = on('on:goal:update', () => {
+            utils.project.getUserProjectsWithGoals.invalidate();
+        });
+
+        const unsubDelete = on('on:goal:delete', () => {
+            utils.project.getUserProjectsWithGoals.invalidate();
+        });
+
+        return () => {
+            unsubUpdate();
+            unsubDelete();
+        };
+    }, [on, utils.project.getUserProjectsWithGoals]);
 
     useEffect(() => {
         const isGoalDeletedAlready = preview && !goals?.some((g) => g.id === preview.id);

--- a/src/components/FlatGoalList.tsx
+++ b/src/components/FlatGoalList.tsx
@@ -19,7 +19,8 @@ interface GoalListProps {
 const pageSize = 20;
 
 export const FlatGoalList: React.FC<GoalListProps> = ({ queryState, setTagFilterOutside }) => {
-    const { preview, setPreview } = useGoalPreview();
+    const utils = trpc.useContext();
+    const { preview, setPreview, on } = useGoalPreview();
 
     const [, setPage] = useState(0);
     const { data, fetchNextPage, hasNextPage } = trpc.goal.getBatch.useInfiniteQuery(
@@ -33,6 +34,20 @@ export const FlatGoalList: React.FC<GoalListProps> = ({ queryState, setTagFilter
             staleTime: refreshInterval,
         },
     );
+
+    useEffect(() => {
+        const unsubUpdate = on('on:goal:update', () => {
+            utils.goal.getBatch.invalidate();
+        });
+        const unsubDelete = on('on:goal:delete', () => {
+            utils.goal.getBatch.invalidate();
+        });
+
+        return () => {
+            unsubUpdate();
+            unsubDelete();
+        };
+    }, [on, utils.goal.getBatch]);
 
     useFMPMetric(!!data);
 

--- a/src/components/GoalActivityFeed.tsx
+++ b/src/components/GoalActivityFeed.tsx
@@ -27,10 +27,11 @@ interface GoalActivityFeedProps {
     onGoalCriteriaClick?: ComponentProps<typeof GoalCriteria>['onClick'];
     onGoalDependencyClick?: ComponentProps<typeof GoalDependencyListByKind>['onClick'];
     onGoalDeleteConfirm?: () => void;
+    onInvalidate?: () => void;
 }
 
 export const GoalActivityFeed = forwardRef<HTMLDivElement, GoalActivityFeedProps>(
-    ({ goal, shortId, onGoalCriteriaClick, onGoalDependencyClick, onGoalDeleteConfirm }, ref) => {
+    ({ goal, shortId, onGoalCriteriaClick, onGoalDependencyClick, onGoalDeleteConfirm, onInvalidate }, ref) => {
         const { user } = usePageContext();
         const {
             onGoalCommentUpdate,
@@ -58,11 +59,12 @@ export const GoalActivityFeed = forwardRef<HTMLDivElement, GoalActivityFeedProps
                 invalidate: {
                     getById: shortId,
                 },
+                afterInvalidate: onInvalidate,
             },
         );
 
-        const onConfirmDeletingGoal = useCallback(() => {
-            onGoalDelete();
+        const onConfirmDeletingGoal = useCallback(async () => {
+            await onGoalDelete();
             onGoalDeleteConfirm?.();
         }, [onGoalDelete, onGoalDeleteConfirm]);
 

--- a/src/components/GoalEditForm/GoalEditForm.tsx
+++ b/src/components/GoalEditForm/GoalEditForm.tsx
@@ -11,6 +11,7 @@ import { trpc } from '../../utils/trpcClient';
 import { useGoalResource } from '../../hooks/useGoalResource';
 import { getDateStringFromEstimate } from '../../utils/dateTime';
 import { goalForm, goalUpdateButton } from '../../utils/domObjects';
+import { dispatchPreviewUpdateEvent } from '../GoalPreview/GoalPreviewProvider';
 
 import { tr } from './GoalEditForm.i18n';
 
@@ -30,6 +31,7 @@ const GoalEditForm: React.FC<GoalEditFormProps> = ({ goal, onSubmit }) => {
             invalidate: {
                 getById: goal._shortId,
             },
+            afterInvalidate: dispatchPreviewUpdateEvent,
         },
     );
 
@@ -42,7 +44,7 @@ const GoalEditForm: React.FC<GoalEditFormProps> = ({ goal, onSubmit }) => {
 
         onSubmit(updatedGoal);
         utils.project.getDeepInfo.invalidate({ id: form.parent.id });
-        invalidate();
+        await invalidate();
     };
 
     const estimateValue = useMemo(

--- a/src/components/GoalHeader.tsx
+++ b/src/components/GoalHeader.tsx
@@ -1,9 +1,10 @@
 import { nullable } from '@taskany/bricks';
-import { ComponentProps, FC, ReactNode } from 'react';
+import { ComponentProps, FC, ReactNode, useCallback } from 'react';
 import styled from 'styled-components';
 
 import { GoalByIdReturnType } from '../../trpc/inferredTypes';
 import { goalPageHeader } from '../utils/domObjects';
+import { ModalEvent, dispatchModalEvent } from '../utils/dispatchModal';
 
 import StateSwitch from './StateSwitch';
 import { State } from './State';
@@ -53,6 +54,15 @@ export const GoalHeader: FC<GoalHeaderProps> = ({
     onGoalStateChange,
     onCommentsClick,
 }) => {
+    const onStateChangeHandler = useCallback<NonNullable<GoalHeaderProps['onGoalStateChange']>>(
+        (val) => {
+            onGoalStateChange?.(val);
+            dispatchModalEvent(ModalEvent.GoalPreviewModal, {
+                type: 'on:goal:update',
+            });
+        },
+        [onGoalStateChange],
+    );
     return (
         <StyledGoalHeader {...goalPageHeader.attr}>
             <StyledGoalInfo align="left">
@@ -66,7 +76,7 @@ export const GoalHeader: FC<GoalHeaderProps> = ({
                     <StyledPublicActions>
                         {nullable(g?.state, (s) =>
                             g._isEditable && g.project?.flowId ? (
-                                <StateSwitch state={s} flowId={g.project.flowId} onClick={onGoalStateChange} />
+                                <StateSwitch state={s} flowId={g.project.flowId} onClick={onStateChangeHandler} />
                             ) : (
                                 <State title={s.title} hue={s.hue} />
                             ),

--- a/src/components/GoalPage/GoalPage.tsx
+++ b/src/components/GoalPage/GoalPage.tsx
@@ -100,7 +100,22 @@ export const GoalPage = ({ user, ssrTime, params: { id } }: ExternalPageProps<{ 
         })
         .join('');
 
-    const { setPreview } = useGoalPreview();
+    const { setPreview, on } = useGoalPreview();
+
+    useEffect(() => {
+        const unsubUpdate = on('on:goal:update', () => {
+            invalidate();
+        });
+
+        const unsubDelete = on('on:goal:delete', () => {
+            invalidate();
+        });
+
+        return () => {
+            unsubUpdate();
+            unsubDelete();
+        };
+    }, [on, invalidate]);
 
     const onGoalCriteriaClick = useCallback(
         (item: GoalAchiveCriteria) => {

--- a/src/components/GoalPreview/GoalPreviewProvider.tsx
+++ b/src/components/GoalPreview/GoalPreviewProvider.tsx
@@ -1,14 +1,35 @@
-import React, { createContext, FC, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+import React, {
+    createContext,
+    FC,
+    ReactNode,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 
 import { refreshInterval } from '../../utils/config';
 import { GoalByIdReturnType } from '../../../trpc/inferredTypes';
 import { trpc } from '../../utils/trpcClient';
+import { ModalEvent, MapModalToComponentProps, dispatchModalEvent } from '../../utils/dispatchModal';
+
+type GoalPreviewEvent = MapModalToComponentProps['GoalPreviewModal']['type'];
+
+type Unsub = () => void;
+type Listener = (id: string) => void;
+type Sub = (type: GoalPreviewEvent, cb: Listener) => Unsub;
+type GoalPreviewEmitter = {
+    [key in GoalPreviewEvent]: Listener[];
+};
 
 type ContextType = {
     shortId: string | null;
     preview: GoalByIdReturnType | null;
     defaults: Partial<GoalByIdReturnType> | null;
     setPreview: (shortId: string | null, defaults?: Partial<GoalByIdReturnType>) => void;
+    on: Sub;
 };
 
 const GoalPreviewProviderContext = createContext<ContextType>({
@@ -16,6 +37,7 @@ const GoalPreviewProviderContext = createContext<ContextType>({
     preview: null,
     defaults: null,
     setPreview: () => {},
+    on: () => () => {},
 });
 
 export const useGoalPreview = () => {
@@ -25,6 +47,11 @@ export const useGoalPreview = () => {
 export const GoalPreviewProvider: FC<{ children: ReactNode }> = ({ children }) => {
     const [shortId, setPreviewId] = useState<string | null>(null);
     const [defaults, setDefaults] = useState<Partial<GoalByIdReturnType> | null>(null);
+
+    const eventsRef = useRef<GoalPreviewEmitter>({
+        'on:goal:delete': [],
+        'on:goal:update': [],
+    });
 
     const { data: preview = null } = trpc.goal.getById.useQuery(shortId as string, {
         staleTime: refreshInterval,
@@ -36,10 +63,43 @@ export const GoalPreviewProvider: FC<{ children: ReactNode }> = ({ children }) =
         setDefaults(shortId ? defaults : null);
     }, []);
 
+    useEffect(() => {
+        const listener = (event: CustomEvent<MapModalToComponentProps[ModalEvent.GoalPreviewModal]>) => {
+            if (!shortId) {
+                return;
+            }
+            for (const fn of eventsRef.current[event.detail.type]) {
+                fn(shortId);
+            }
+        };
+
+        window.addEventListener(ModalEvent.GoalPreviewModal, listener);
+
+        return () => {
+            window.removeEventListener(ModalEvent.GoalPreviewModal, listener);
+        };
+    }, [shortId]);
+
+    const subscribe = useCallback<Sub>((type, cb) => {
+        eventsRef.current[type].push(cb);
+        return () => {
+            eventsRef.current[type] = eventsRef.current[type].filter((fn) => fn !== cb);
+        };
+    }, []);
+
     const value = useMemo(
-        () => ({ shortId, preview: shortId ? preview : null, defaults: shortId ? defaults : null, setPreview }),
-        [shortId, preview, defaults, setPreview],
+        () => ({
+            shortId,
+            preview: shortId ? preview : null,
+            defaults: shortId ? defaults : null,
+            setPreview,
+            on: subscribe,
+        }),
+        [shortId, preview, defaults, setPreview, subscribe],
     );
 
     return <GoalPreviewProviderContext.Provider value={value}>{children}</GoalPreviewProviderContext.Provider>;
 };
+
+export const dispatchPreviewUpdateEvent = dispatchModalEvent(ModalEvent.GoalPreviewModal, { type: 'on:goal:update' });
+export const dispatchPreviewDeleteEvent = dispatchModalEvent(ModalEvent.GoalPreviewModal, { type: 'on:goal:delete' });

--- a/src/components/GoalSidebar/GoalSidebar.tsx
+++ b/src/components/GoalSidebar/GoalSidebar.tsx
@@ -17,6 +17,7 @@ import { ProjectBadge } from '../ProjectBadge';
 import { TextList, TextListItem } from '../TextList';
 import { safeUserData } from '../../utils/getUserName';
 import { goalPageDeleteButton } from '../../utils/domObjects';
+import { dispatchPreviewUpdateEvent } from '../GoalPreview/GoalPreviewProvider';
 
 import { tr } from './GoalSidebar.i18n';
 
@@ -75,6 +76,7 @@ export const GoalSidebar: FC<GoalSidebarProps> = ({ goal, onGoalTagRemove, onGoa
                 invalidate: {
                     getById: goal._shortId,
                 },
+                afterInvalidate: dispatchPreviewUpdateEvent,
             },
         );
 

--- a/src/components/ProjectPage/ProjectPage.tsx
+++ b/src/components/ProjectPage/ProjectPage.tsx
@@ -60,7 +60,23 @@ export const ProjectPage = ({ user, ssrTime, params: { id }, defaultPresetFallba
         },
     );
 
-    const { preview, setPreview } = useGoalPreview();
+    const { preview, setPreview, on } = useGoalPreview();
+
+    useEffect(() => {
+        const unsubUpdate = on('on:goal:update', () => {
+            utils.project.getById.invalidate();
+            utils.project.getDeepInfo.invalidate();
+        });
+        const unsubDelete = on('on:goal:delete', () => {
+            utils.project.getById.invalidate();
+            utils.project.getDeepInfo.invalidate();
+        });
+
+        return () => {
+            unsubUpdate();
+            unsubDelete();
+        };
+    }, [on, utils.project.getDeepInfo, utils.project.getById]);
 
     const onGoalPrewiewShow = useCallback(
         (goal: GoalByIdReturnType): MouseEventHandler<HTMLAnchorElement> =>

--- a/src/utils/dispatchModal.ts
+++ b/src/utils/dispatchModal.ts
@@ -14,6 +14,7 @@ export enum ModalEvent {
     FeedbackCreateModal = 'FeedbackCreateModal',
     WhatsNewModal = 'WhatsNewModal',
     ImageFullScreen = 'ImageFullScreen',
+    GoalPreviewModal = 'GoalPreviewModal',
 }
 
 export interface MapModalToComponentProps {
@@ -36,6 +37,9 @@ export interface MapModalToComponentProps {
     [ModalEvent.ImageFullScreen]: {
         src: string;
         alt?: string;
+    };
+    [ModalEvent.GoalPreviewModal]: {
+        type: 'on:goal:update' | 'on:goal:delete';
     };
 }
 


### PR DESCRIPTION
Based on native events which dispatching from GoalPreview components through useGoalPreview hook.
I'm not sure about event names for this feature `on:goal:update | on:goal:delete`

Example

```ts
const { on } = useGoalPreview();

useEffect(() => {
    const unsub = on('on:goal:update', () => {
         // any logic after update goal in preview
    })
    return () => unsub();
}, [on, ...])
```

## PR includes

- [x] Bug Fix
- [x] Feature

## Related issues

Resolve #1812 

## QA Instructions, Screenshots, Recordings
  
https://github.com/taskany-inc/issues/assets/7002692/3fc4a218-605d-4cc4-9306-7c6aac241915
