### PR TITLE
Enable Group/Ungroup control

### DIFF
--- a/src/components/GoalsPage/GoalsPage.tsx
+++ b/src/components/GoalsPage/GoalsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { FiltersMenuItem, nullable } from '@taskany/bricks';
 
 import { ExternalPageProps } from '../../utils/declareSsrProps';
 import { trpc } from '../../utils/trpcClient';
@@ -10,6 +11,7 @@ import { PageTitlePreset } from '../PageTitlePreset/PageTitlePreset';
 import { safeGetUserName } from '../../utils/getUserName';
 import { FilteredPage } from '../FilteredPage/FilteredPage';
 import { GroupedGoalList } from '../GroupedGoalList';
+import { FlatGoalList } from '../FlatGoalList';
 
 import { tr } from './GoalsPage.i18n';
 
@@ -20,7 +22,7 @@ export const GoalsPage = ({ user, ssrTime, defaultPresetFallback }: ExternalPage
         defaultPresetFallback,
     });
 
-    const { currentPreset, queryState, setTagsFilterOutside, setPreset } = useUrlFilterParams({
+    const { currentPreset, queryState, setTagsFilterOutside, setPreset, setGroupedView } = useUrlFilterParams({
         preset,
     });
 
@@ -36,6 +38,8 @@ export const GoalsPage = ({ user, ssrTime, defaultPresetFallback }: ExternalPage
         currentPreset && currentPreset.description
             ? currentPreset.description
             : tr('These are goals across all projects');
+
+    const groupedView = queryState?.groupBy === 'project';
 
     return (
         <Page user={user} ssrTime={ssrTime} title={tr('title')}>
@@ -56,7 +60,6 @@ export const GoalsPage = ({ user, ssrTime, defaultPresetFallback }: ExternalPage
                 }
                 description={description}
             />
-            {/** TODO: https://github.com/taskany-inc/issues/issues/1881 */}
             <FilteredPage
                 total={data?.count || 0}
                 counter={data?.filtered || 0}
@@ -64,25 +67,26 @@ export const GoalsPage = ({ user, ssrTime, defaultPresetFallback }: ExternalPage
                 userFilters={userFilters}
                 onFilterStar={onFilterStar}
                 isLoading={false}
-                // filterControls={nullable(
-                //     !queryState?.groupBy,
-                //     () => (
-                //         <FiltersMenuItem onClick={() => setGroupedView('project')}>{tr('Group')}</FiltersMenuItem>
-                //     ),
-                //     <FiltersMenuItem active onClick={() => setGroupedView()}>
-                //         {tr('Ungroup')}
-                //     </FiltersMenuItem>,
-                // )}
-            >
-                {/** TODO: https://github.com/taskany-inc/issues/issues/1881 */}
-                {/* {nullable(
-                    !queryState?.groupBy,
+                filterControls={nullable(
+                    groupedView,
                     () => (
-                        <FlatGoalList queryState={queryState} setTagFilterOutside={setTagsFilterOutside} />
+                        <FiltersMenuItem
+                            active
+                            onClick={() => setGroupedView(queryState?.groupBy ? 'none' : undefined)}
+                        >
+                            {tr('Ungroup')}
+                        </FiltersMenuItem>
                     ),
-                    <GroupedGoalList queryState={queryState} setTagFilterOutside={setTagsFilterOutside} />,
-                )} */}
-                <GroupedGoalList queryState={queryState} setTagFilterOutside={setTagsFilterOutside} />
+                    <FiltersMenuItem onClick={() => setGroupedView('project')}>{tr('Group')}</FiltersMenuItem>,
+                )}
+            >
+                {nullable(
+                    groupedView,
+                    () => (
+                        <GroupedGoalList queryState={queryState} setTagFilterOutside={setTagsFilterOutside} />
+                    ),
+                    <FlatGoalList queryState={queryState} setTagFilterOutside={setTagsFilterOutside} />,
+                )}
             </FilteredPage>
         </Page>
     );

--- a/src/hooks/useFiltersPreset.ts
+++ b/src/hooks/useFiltersPreset.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useRouter } from 'next/router';
 
 import { trpc } from '../utils/trpcClient';
@@ -23,19 +23,20 @@ export const useFiltersPreset = ({ defaultPresetFallback = true }: { defaultPres
         staleTime: refreshInterval,
     });
 
-    const shadowPreset = userFilters.data?.filter(
-        (f) => decodeURIComponent(f.params) === decodeURIComponent(queryString),
-    )[0];
-
     useEffect(() => {
         if (!defaultPresetFallback) {
             deleteCookie(filtersNoSearchPresetCookie);
         }
     }, [defaultPresetFallback]);
 
-    return {
-        preset: preset.data,
-        shadowPreset,
-        userFilters: userFilters.data,
-    };
+    return useMemo(
+        () => ({
+            preset: preset.data,
+            shadowPreset: userFilters.data?.find(
+                (f) => decodeURIComponent(f.params) === decodeURIComponent(queryString),
+            ),
+            userFilters: userFilters.data,
+        }),
+        [preset.data, userFilters.data, queryString],
+    );
 };

--- a/src/hooks/useUrlFilterParams.ts
+++ b/src/hooks/useUrlFilterParams.ts
@@ -27,6 +27,7 @@ export interface FilterQueryState {
 
 const groupByValue = {
     project: true,
+    none: true,
 };
 
 type GroupByParam = keyof typeof groupByValue;
@@ -115,7 +116,7 @@ export const buildURLSearchParams = ({
 
     watching ? urlParams.set('watching', '1') : urlParams.delete('watching');
 
-    groupBy != null ? urlParams.set('groupBy', groupBy) : urlParams.delete('groupBy');
+    groupBy === 'project' ? urlParams.set('groupBy', groupBy) : urlParams.delete('groupBy');
 
     limit ? urlParams.set('limit', limit.toString()) : urlParams.delete('limit');
 
@@ -155,6 +156,22 @@ export const parseQueryState = (query: ParsedUrlQuery) => {
     };
 };
 
+function makeGroupByParam(queryState?: QueryState, preset?: FilterById) {
+    const parsedPresetParams = preset ? Object.fromEntries(new URLSearchParams(preset.params)) : null;
+    const presetGroupBy = parsedPresetParams?.groupBy;
+    const queryGroupBy = queryState?.groupBy;
+
+    if (presetGroupBy) {
+        return { preset: presetGroupBy };
+    }
+
+    if (queryGroupBy) {
+        return { query: queryGroupBy };
+    }
+
+    return null;
+}
+
 export const useUrlFilterParams = ({ preset }: { preset?: FilterById }) => {
     const router = useRouter();
     const [currentPreset, setCurrentPreset] = useState(preset);
@@ -165,6 +182,10 @@ export const useUrlFilterParams = ({ preset }: { preset?: FilterById }) => {
         const { queryState = undefined, queryFilterState = undefined } = Object.keys(query).length
             ? parseQueryState(query)
             : {};
+
+        if ('groupBy' in router.query && queryState != null) {
+            queryState.groupBy = router.query.groupBy as BaseQueryState['groupBy'];
+        }
 
         return {
             queryFilterState,
@@ -286,6 +307,39 @@ export const useUrlFilterParams = ({ preset }: { preset?: FilterById }) => {
         [router],
     );
 
+    const setGroupedView = useCallback(
+        (value?: BaseQueryState['groupBy']) => {
+            const { query } = router;
+
+            const nextQuery = { ...query };
+
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            const currentGroupByValue = makeGroupByParam(queryState, currentPreset);
+
+            if (currentGroupByValue == null) {
+                nextQuery.groupBy = value;
+            } else if (currentGroupByValue.preset) {
+                if (currentGroupByValue.preset === value) {
+                    delete nextQuery.groupBy;
+                } else {
+                    nextQuery.groupBy = value;
+                }
+            } else if (currentGroupByValue.query) {
+                if (currentGroupByValue.query === value || value === 'none') {
+                    delete nextQuery.groupBy;
+                } else {
+                    nextQuery.groupBy = value;
+                }
+            }
+
+            router.push({
+                pathname: router.asPath.split('?')[0],
+                query: nextQuery,
+            });
+        },
+        [currentPreset, queryState, router],
+    );
+
     const setters = useMemo(
         () => ({
             setPriorityFilter: pushStateProvider.key('priority'),
@@ -302,7 +356,6 @@ export const useUrlFilterParams = ({ preset }: { preset?: FilterById }) => {
             setSortFilter: pushStateProvider.key('sort'),
             setFulltextFilter: pushStateProvider.key('query'),
             setLimitFilter: pushStateProvider.key('limit'),
-            setGroupedView: pushStateProvider.key('groupBy'),
             batchQueryState: pushStateProvider.batch(),
         }),
         [pushStateProvider],
@@ -316,6 +369,7 @@ export const useUrlFilterParams = ({ preset }: { preset?: FilterById }) => {
         setTagsFilterOutside,
         resetQueryState,
         setPreset,
+        setGroupedView,
         ...setters,
     };
 };


### PR DESCRIPTION
## PR includes

- [x] Bug Fix

## Related issues

Resolve #1881 

## QA Instructions, Screenshots, Recordings
 
Filter preset with groupBy param
<img width="897" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/a13f1208-d28b-4d0d-8eff-e764c6e65456">

Same Filter preset with additional ungroup param. Click by `Ungroup` is append query param `groupBy=none` which overriding contains params value in preset
<img width="897" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/cee9eafd-b3fe-4906-a7d3-1751701eaa3a">

Preset without groupping
<img width="897" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/fd9d903d-96cf-4260-ac03-5dbc248cea90">

Preset without groupping with overriding query param
<img width="897" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/c479fba4-3782-4d12-b8f6-522697eaa2f8">

Any custom filter params with groupping param
<img width="897" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/f8220ac7-ebc8-4f7f-9944-6114edc75895">
