### PR TITLE
Enable Group/Ungroup control

### DIFF
--- a/src/components/GoalsPage/GoalsPage.tsx
+++ b/src/components/GoalsPage/GoalsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { FiltersMenuItem, nullable } from '@taskany/bricks';
 
 import { ExternalPageProps } from '../../utils/declareSsrProps';
 import { trpc } from '../../utils/trpcClient';
@@ -10,6 +11,7 @@ import { PageTitlePreset } from '../PageTitlePreset/PageTitlePreset';
 import { safeGetUserName } from '../../utils/getUserName';
 import { FilteredPage } from '../FilteredPage/FilteredPage';
 import { GroupedGoalList } from '../GroupedGoalList';
+import { FlatGoalList } from '../FlatGoalList';
 
 import { tr } from './GoalsPage.i18n';
 
@@ -20,7 +22,7 @@ export const GoalsPage = ({ user, ssrTime, defaultPresetFallback }: ExternalPage
         defaultPresetFallback,
     });
 
-    const { currentPreset, queryState, setTagsFilterOutside, setPreset } = useUrlFilterParams({
+    const { currentPreset, queryState, setTagsFilterOutside, setPreset, setGroupedView } = useUrlFilterParams({
         preset,
     });
 
@@ -36,6 +38,8 @@ export const GoalsPage = ({ user, ssrTime, defaultPresetFallback }: ExternalPage
         currentPreset && currentPreset.description
             ? currentPreset.description
             : tr('These are goals across all projects');
+
+    const groupedView = queryState?.groupBy === 'project';
 
     return (
         <Page user={user} ssrTime={ssrTime} title={tr('title')}>
@@ -56,7 +60,6 @@ export const GoalsPage = ({ user, ssrTime, defaultPresetFallback }: ExternalPage
                 }
                 description={description}
             />
-            {/** TODO: https://github.com/taskany-inc/issues/issues/1881 */}
             <FilteredPage
                 total={data?.count || 0}
                 counter={data?.filtered || 0}
@@ -64,25 +67,26 @@ export const GoalsPage = ({ user, ssrTime, defaultPresetFallback }: ExternalPage
                 userFilters={userFilters}
                 onFilterStar={onFilterStar}
                 isLoading={false}
-                // filterControls={nullable(
-                //     !queryState?.groupBy,
-                //     () => (
-                //         <FiltersMenuItem onClick={() => setGroupedView('project')}>{tr('Group')}</FiltersMenuItem>
-                //     ),
-                //     <FiltersMenuItem active onClick={() => setGroupedView()}>
-                //         {tr('Ungroup')}
-                //     </FiltersMenuItem>,
-                // )}
-            >
-                {/** TODO: https://github.com/taskany-inc/issues/issues/1881 */}
-                {/* {nullable(
-                    !queryState?.groupBy,
+                filterControls={nullable(
+                    groupedView,
                     () => (
-                        <FlatGoalList queryState={queryState} setTagFilterOutside={setTagsFilterOutside} />
+                        <FiltersMenuItem
+                            active
+                            onClick={() => setGroupedView(queryState?.groupBy ? 'none' : undefined)}
+                        >
+                            {tr('Ungroup')}
+                        </FiltersMenuItem>
                     ),
-                    <GroupedGoalList queryState={queryState} setTagFilterOutside={setTagsFilterOutside} />,
-                )} */}
-                <GroupedGoalList queryState={queryState} setTagFilterOutside={setTagsFilterOutside} />
+                    <FiltersMenuItem onClick={() => setGroupedView('project')}>{tr('Group')}</FiltersMenuItem>,
+                )}
+            >
+                {nullable(
+                    groupedView,
+                    () => (
+                        <GroupedGoalList queryState={queryState} setTagFilterOutside={setTagsFilterOutside} />
+                    ),
+                    <FlatGoalList queryState={queryState} setTagFilterOutside={setTagsFilterOutside} />,
+                )}
             </FilteredPage>
         </Page>
     );

--- a/src/hooks/useFiltersPreset.ts
+++ b/src/hooks/useFiltersPreset.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useRouter } from 'next/router';
 
 import { trpc } from '../utils/trpcClient';
@@ -23,19 +23,20 @@ export const useFiltersPreset = ({ defaultPresetFallback = true }: { defaultPres
         staleTime: refreshInterval,
     });
 
-    const shadowPreset = userFilters.data?.filter(
-        (f) => decodeURIComponent(f.params) === decodeURIComponent(queryString),
-    )[0];
-
     useEffect(() => {
         if (!defaultPresetFallback) {
             deleteCookie(filtersNoSearchPresetCookie);
         }
     }, [defaultPresetFallback]);
 
-    return {
-        preset: preset.data,
-        shadowPreset,
-        userFilters: userFilters.data,
-    };
+    return useMemo(
+        () => ({
+            preset: preset.data,
+            shadowPreset: userFilters.data?.find(
+                (f) => decodeURIComponent(f.params) === decodeURIComponent(queryString),
+            ),
+            userFilters: userFilters.data,
+        }),
+        [preset.data, userFilters.data, queryString],
+    );
 };

--- a/src/pages/goals/index.tsx
+++ b/src/pages/goals/index.tsx
@@ -10,10 +10,18 @@ export const getServerSideProps = declareSsrProps(
 
         const { queryState, defaultPresetFallback } = await filtersPanelSsrInit(props);
 
-        await ssrHelpers.goal.getBatch.fetchInfinite({
-            limit: pageSize,
-            query: queryState,
-        });
+        if (queryState.groupBy === 'project') {
+            await ssrHelpers.project.getAll.fetchInfinite({
+                limit: pageSize,
+                goalsQuery: queryState,
+                firstLevel: !!queryState.project.length,
+            });
+        } else {
+            await ssrHelpers.goal.getBatch.fetchInfinite({
+                limit: pageSize,
+                query: queryState,
+            });
+        }
 
         await ssrHelpers.goal.getGoalsCount.fetch({
             query: queryState,


### PR DESCRIPTION
## PR includes

- [x] Bug Fix

## Related issues

Resolve #1881 

## QA Instructions, Screenshots, Recordings
 
Filter preset with groupBy param
<img width="897" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/a13f1208-d28b-4d0d-8eff-e764c6e65456">

Same Filter preset with additional ungroup param. Click by `Ungroup` is append query param `groupBy=none` which overriding contains params value in preset
<img width="897" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/cee9eafd-b3fe-4906-a7d3-1751701eaa3a">

Preset without grouping
<img width="897" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/fd9d903d-96cf-4260-ac03-5dbc248cea90">

Preset without groupping with overriding query param
<img width="897" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/c479fba4-3782-4d12-b8f6-522697eaa2f8">

Any custom filter params with grouping param
<img width="897" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/f8220ac7-ebc8-4f7f-9944-6114edc75895">

Applied preset by default doesn't reset after apply group by projects
<img width="848" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/80b3ae41-9598-457b-bacf-e5e78683169a">

