### PR TITLE
The chaos of loading goals in grouped view on /goals page

### DIFF
--- a/src/components/CollapsableItem.tsx
+++ b/src/components/CollapsableItem.tsx
@@ -195,7 +195,7 @@ export const CollapsableItem: FC<React.PropsWithChildren<CollapsableItemProps>> 
             {nullable(children, (ch) => (
                 <StyledCollapsableItem>{ch}</StyledCollapsableItem>
             ))}
-            {!collapsed ? content : null}
+            {nullable(content, (c) => !collapsed && c)}
         </StyledCollapsableContainer>
     );
 };

--- a/src/components/ProjectListItemConnected.tsx
+++ b/src/components/ProjectListItemConnected.tsx
@@ -35,7 +35,7 @@ export const ProjectListItemConnected: FC<{
     const { on } = useGoalPreview();
     const utils = trpc.useContext();
 
-    const { data: projectDeepInfo } = trpc.project.getDeepInfo.useQuery(
+    const { data: projectDeepInfo, isLoading: isDeepInfoLoading } = trpc.project.getDeepInfo.useQuery(
         {
             id: project.id,
             goalsQuery: queryState,
@@ -120,9 +120,10 @@ export const ProjectListItemConnected: FC<{
             deep={deep}
             contentHidden={contentHidden}
         >
-            {nullable(!projectDeepInfo?.goals.length && status !== 'loading', () => (
-                <InlineCreateGoalControl projectId={project.id} />
-            ))}
+            {nullable(
+                !projectDeepInfo?.goals.length,
+                () => !isDeepInfoLoading && <InlineCreateGoalControl projectId={project.id} />,
+            )}
             {childrenProjects.map((p) => (
                 <ProjectListItemConnected
                     key={p.id}


### PR DESCRIPTION
Fix blinking `Create goal` control by open collapse element

## PR includes

- [x] Bug Fix

## Related issues

Resolve #1886 
