### PR TITLE
First level projects are not clickable by cmd+click

### DIFF
--- a/src/components/GroupedGoalList.tsx
+++ b/src/components/GroupedGoalList.tsx
@@ -79,6 +79,7 @@ export const GroupedGoalList: React.FC<GroupedGoalListProps> = ({ queryState, se
                     onClickProvider={onGoalPrewiewShow}
                     selectedResolver={selectedGoalResolver}
                     queryState={queryState}
+                    hasLink
                     collapsed
                 />
             ))}

--- a/src/components/ProjectPage/ProjectPage.tsx
+++ b/src/components/ProjectPage/ProjectPage.tsx
@@ -197,8 +197,6 @@ export const ProjectPage = ({ user, ssrTime, params: { id }, defaultPresetFallba
                         onClickProvider={onGoalPrewiewShow}
                         selectedResolver={selectedGoalResolver}
                         queryState={queryState}
-                        collapsed={!id}
-                        hasLink={!id}
                     />
                 ))}
             </FilteredPage>


### PR DESCRIPTION
In GoalsPage `cmd+click` is works again
In ProjectPage don't need this behavior for first-level project

## PR includes

- [x] Bug Fix

## Related issues

Resolve #1907 
