### PR TITLE
Make responsive markup great again

### DIFF
--- a/src/components/DashboardPage/DashboardPage.tsx
+++ b/src/components/DashboardPage/DashboardPage.tsx
@@ -144,6 +144,7 @@ export const DashboardPage = ({ user, ssrTime, defaultPresetFallback }: External
                                 <TableRowItem
                                     title={<Title size="m">{g.title}</Title>}
                                     onClick={onGoalPreviewShow(g as GoalByIdReturnType)}
+                                    focused={selectedGoalResolver(g.id)}
                                 >
                                     <GoalListItem
                                         createdAt={g.createdAt}
@@ -161,7 +162,6 @@ export const DashboardPage = ({ user, ssrTime, defaultPresetFallback }: External
                                         starred={g._isStarred}
                                         watching={g._isWatching}
                                         achivedCriteriaWeight={g._achivedCriteriaWeight}
-                                        focused={selectedGoalResolver(g.id)}
                                         onTagClick={setTagsFilterOutside}
                                     />
                                 </TableRowItem>

--- a/src/components/FilteredPage/FilteredPage.tsx
+++ b/src/components/FilteredPage/FilteredPage.tsx
@@ -17,6 +17,7 @@ import { PresetDropdown } from '../PresetDropdown';
 import { LimitDropdown } from '../LimitDropdown';
 import { StarredFilter } from '../StarredFilter/StarredFilter';
 import { WatchingFilter } from '../WatchingFilter/WatchingFilter';
+import { ScrollableView } from '../ScrollableView';
 
 import { tr } from './FilteredPage.i18n';
 
@@ -160,7 +161,9 @@ export const FilteredPage: React.FC<React.PropsWithChildren<FilteredPageProps>> 
                 </StyledFilterControls>
             </FiltersPanel>
 
-            <PageContent>{children}</PageContent>
+            <PageContent>
+                <ScrollableView>{children}</ScrollableView>
+            </PageContent>
 
             {nullable(queryString, (params) => (
                 <ModalOnEvent event={ModalEvent.FilterCreateModal} hotkeys={createFilterKeys}>

--- a/src/components/GoalListItem.tsx
+++ b/src/components/GoalListItem.tsx
@@ -132,7 +132,6 @@ export const GoalListItem: React.FC<GoalListItemProps> = React.memo(
         tags,
         comments,
         state,
-        focused,
         estimate,
         estimateType,
         priority,
@@ -152,7 +151,7 @@ export const GoalListItem: React.FC<GoalListItemProps> = React.memo(
         }, [issuer, owner]);
 
         return (
-            <TableRow focused={focused} className={className} gap={10} align="center" interactive>
+            <TableRow className={className} gap={10} align="center">
                 <TableCell width="90px">
                     {nullable(state, (s) => (
                         <State size="s" title={s?.title} hue={s?.hue} />

--- a/src/components/ProjectListItemCollapsable/ProjectListItemCollapsable.tsx
+++ b/src/components/ProjectListItemCollapsable/ProjectListItemCollapsable.tsx
@@ -22,6 +22,10 @@ const StyledTitleWrapper = styled(StyledProjectIcons)`
     margin-right: ${gapS};
 `;
 
+const StyledTreeViewNode = styled(TreeViewNode)`
+    width: fit-content;
+`;
+
 interface ProjectListItemCollapsableProps extends Omit<ComponentProps<typeof TreeViewNode>, 'title'> {
     href?: string;
     project: Omit<NonNullable<ProjectByIdReturnType>, '_count'>;
@@ -69,7 +73,7 @@ export const ProjectListItemCollapsable: React.FC<ProjectListItemCollapsableProp
 
     return (
         <TreeView className={className} {...projectListItem.attr}>
-            <TreeViewNode
+            <StyledTreeViewNode
                 interactive={interactive}
                 title={nullable(
                     href,
@@ -84,7 +88,7 @@ export const ProjectListItemCollapsable: React.FC<ProjectListItemCollapsableProp
             >
                 {goals}
                 {children}
-            </TreeViewNode>
+            </StyledTreeViewNode>
         </TreeView>
     );
 };

--- a/src/components/ProjectListItemConnected.tsx
+++ b/src/components/ProjectListItemConnected.tsx
@@ -86,6 +86,7 @@ export const ProjectListItemConnected: FC<ProjectListItemConnectedProps> = ({
                     <Link as={NextLink} href={routes.goal(g._shortId)} inline>
                         <TableRowItem
                             title={<Title size="m">{g.title}</Title>}
+                            focused={selectedResolver?.(g.id)}
                             onClick={(e) => {
                                 onClickProvider?.(g as NonNullable<GoalByIdReturnType>)(e);
                                 onProjectClickHandler(e);
@@ -107,7 +108,6 @@ export const ProjectListItemConnected: FC<ProjectListItemConnectedProps> = ({
                                 starred={g._isStarred}
                                 watching={g._isWatching}
                                 achivedCriteriaWeight={g._achivedCriteriaWeight}
-                                focused={selectedResolver?.(g.id)}
                                 onTagClick={onTagClick}
                             />
                         </TableRowItem>

--- a/src/components/ScrollableView.tsx
+++ b/src/components/ScrollableView.tsx
@@ -1,0 +1,111 @@
+import React, { useCallback, useState, useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import { gapM } from '@taskany/colors';
+
+import { useForkedRef } from '../hooks/useForkedRef';
+
+export interface OverflowScrollProps {
+    className?: string;
+    children: React.ReactNode;
+}
+
+interface OverflowScrollState {
+    left: boolean;
+    right: boolean;
+}
+
+interface StyledShadeProps {
+    position: 'left' | 'right';
+    y?: number;
+    visible?: boolean;
+}
+
+const shadeWidth = 2;
+
+const StyledScrollWrapper = styled.div<OverflowScrollProps>`
+    position: relative;
+    z-index: 1;
+
+    overflow: hidden;
+
+    scrollbar-width: none;
+`;
+
+const StyledScrollContainer = styled.div`
+    overflow-y: hidden;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+`;
+
+const StyledShade = styled.span<StyledShadeProps>`
+    position: absolute;
+    z-index: 1;
+
+    top: calc(${gapM} * -1);
+    bottom: calc(${gapM} * -1);
+    width: ${shadeWidth}px;
+    border-radius: 75%;
+
+    ${({ visible = false }) => ({
+        visibility: visible ? 'visible' : 'hidden',
+        opacity: Number(visible),
+    })}
+    ${({ position }) => ({
+        [`margin-${position}`]: '-1px',
+        [position]: 0,
+
+        boxShadow:
+            'rgba(0, 0, 0, 0.2) 0px 3px 1px -2px, rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 1px 5px 0px',
+    })}
+`;
+
+export const ScrollableView = React.forwardRef<HTMLDivElement, OverflowScrollProps>(({ className, children }, ref) => {
+    const [shades, setShades] = useState<OverflowScrollState>({
+        left: false,
+        right: false,
+    });
+
+    const innerRef = useRef<HTMLDivElement>(null);
+    const forkedRef = useForkedRef(ref, innerRef);
+
+    const onScrollHandler = useCallback(() => {
+        const el = innerRef.current;
+
+        if (el == null) {
+            return;
+        }
+
+        if (el.clientWidth >= el.scrollWidth) {
+            setShades({
+                left: false,
+                right: false,
+            });
+        } else {
+            setShades({
+                left: el.scrollLeft > 0,
+                right: el.scrollLeft + el.clientWidth < el.scrollWidth,
+            });
+        }
+    }, []);
+
+    useEffect(() => {
+        onScrollHandler();
+
+        window.addEventListener('resize', onScrollHandler, { capture: true });
+
+        return () => {
+            window.removeEventListener('resize', onScrollHandler, { capture: true });
+        };
+    }, [onScrollHandler]);
+
+    return (
+        <StyledScrollWrapper className={className} onResizeCapture={onScrollHandler}>
+            <StyledShade key={`left-${shades.left}`} position="left" visible={shades.left} />
+            <StyledShade key={`right-${shades.right}`} position="right" visible={shades.right} />
+
+            <StyledScrollContainer onScroll={onScrollHandler} ref={forkedRef}>
+                {children}
+            </StyledScrollContainer>
+        </StyledScrollWrapper>
+    );
+});

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
-import { gapS, gray6, gray9, radiusM, textColor } from '@taskany/colors';
-import { Text } from '@taskany/bricks';
+import { gapS, gray9, radiusM, textColor } from '@taskany/colors';
+import { TableRow, Text } from '@taskany/bricks';
 import { MouseEventHandler, ReactNode } from 'react';
 
 export const Title = styled(Text).attrs((props) => ({ weight: 'bold', ...props }))``;
@@ -11,30 +11,26 @@ export const TextItem = styled(Text).attrs({
     color: gray9,
 })``;
 
-const TableRowWrapper = styled.div`
+const TableRowWrapper = styled(TableRow)`
     display: grid;
-    grid-template-columns: 1fr 740px;
+    grid-template-columns: 400px 740px;
     align-items: center;
     flex: 1;
 
     color: ${textColor};
     padding: ${gapS};
     border-radius: ${radiusM};
-
-    :hover {
-        background-color: ${gray6};
-        cursor: pointer;
-    }
 `;
 
-interface TableRowItemProps {
+interface TableRowItemProps extends Omit<React.ComponentProps<typeof TableRow>, 'interactive'> {
     title: ReactNode;
     children: ReactNode;
     onClick?: MouseEventHandler<HTMLElement>;
 }
-export const TableRowItem = ({ title, children, onClick }: TableRowItemProps) => {
+
+export const TableRowItem = ({ title, children, onClick, ...attrs }: TableRowItemProps) => {
     return (
-        <TableRowWrapper onClick={onClick}>
+        <TableRowWrapper onClick={onClick} interactive {...attrs}>
             {title}
             {children}
         </TableRowWrapper>


### PR DESCRIPTION
For small screen now will render the shade by sides
Fix focus state for active goal in list

## PR includes

- [x] Bug Fix

## Related issues

Resolve #2090 
Resolve #2133 

## QA Instructions, Screenshots, Recordings

Shade
<img width="602" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/01d75613-4e27-49b7-9bb9-e0005e9d36a4">

Focus
<img width="602" alt="image" src="https://github.com/taskany-inc/issues/assets/7002692/04d33709-d250-44e2-ad0b-6a362b0e2276">


