### PR TITLE
Reactions should be unique

### DIFF
--- a/prisma/migrations/20240131191725_/migration.sql
+++ b/prisma/migrations/20240131191725_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[emoji,commentId,activityId]` on the table `Reaction` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Reaction_emoji_commentId_activityId_key" ON "Reaction"("emoji", "commentId", "activityId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -270,6 +270,7 @@ model Reaction {
   createdAt DateTime @default(dbgenerated("timezone('utc'::text, now())")) @db.Timestamp()
   updatedAt DateTime @default(dbgenerated("timezone('utc'::text, now())")) @updatedAt
 
+  @@unique([emoji, commentId, activityId])
   @@index([activityId])
   @@index([goalId])
   @@index([commentId])
@@ -362,17 +363,17 @@ model GoalHistory {
 }
 
 model GoalAchieveCriteria {
-  id               String   @id @default(cuid())
-  goal             Goal     @relation("GoalCriterion", fields: [goalId], references: [id], onDelete: Cascade)
-  goalId           String
-  title            String
-  weight           Int
-  isDone           Boolean  @default(false)
-  activity         Activity @relation(fields: [activityId], references: [id])
-  activityId       String
-  deleted          Boolean?
-  criteriaGoalId   String?
-  criteriaGoal     Goal?    @relation("GoalInCriteria", fields: [criteriaGoalId], references: [id], onDelete: Cascade)
+  id             String   @id @default(cuid())
+  goal           Goal     @relation("GoalCriterion", fields: [goalId], references: [id], onDelete: Cascade)
+  goalId         String
+  title          String
+  weight         Int
+  isDone         Boolean  @default(false)
+  activity       Activity @relation(fields: [activityId], references: [id])
+  activityId     String
+  deleted        Boolean?
+  criteriaGoalId String?
+  criteriaGoal   Goal?    @relation("GoalInCriteria", fields: [criteriaGoalId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(dbgenerated("timezone('utc'::text, now())")) @db.Timestamp()
   updatedAt DateTime @default(dbgenerated("timezone('utc'::text, now())")) @updatedAt


### PR DESCRIPTION
## PR includes

- [x] Bug Fix

## Related issues

Resolve #2241 

## QA Instructions, Screenshots, Recordings

> [!WARNING]
> Duplicate reactions must be removed to avoid problems.

### Identifying non-unique reactions:

```sql
SELECT emoji, "commentId", "activityId", COUNT(*)
FROM "Reaction"
GROUP BY emoji, "commentId", "activityId"
HAVING COUNT(*) > 1;
```

### Reviewing ids to be removed:

```sql
SELECT id
FROM (
  SELECT
    id,
    ROW_NUMBER() OVER (PARTITION BY emoji, "commentId", "activityId" ORDER BY id) as row_num
  FROM "Reaction"
) AS duplicates
WHERE row_num > 1
```

### Removing duplicates:

```sql
DELETE FROM "Reaction"
WHERE id IN (
  SELECT id
  FROM (
    SELECT
      id,
      ROW_NUMBER() OVER (PARTITION BY emoji, "commentId", "activityId" ORDER BY id) as row_num
    FROM "Reaction"
  ) AS duplicates
  WHERE row_num > 1
);
```