### PR TITLE
Restrict imports from prisma and trpc in client code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,5 +79,16 @@ module.exports = {
             { argsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_', varsIgnorePattern: '^_' },
         ],
         'prefer-destructuring': 'error',
+        'no-restricted-imports': [
+            'warn',
+            {
+                paths: [
+                    {
+                        name: '@prisma/client',
+                        message: 'Use the trpc procedures inferred types instead',
+                    },
+                ],
+            },
+        ],
     },
 };


### PR DESCRIPTION
All count of files which use `import * from '@prisma/client'` is 38 files

```
cypress/plugins/db.ts
src/hooks/useGoalResource.ts
src/hooks/useUrlFilterParams.ts
src/schema/common.ts
src/schema/filter.ts
src/schema/goal.ts
src/types/date.ts
src/types/history.ts
src/utils/auth.ts
src/utils/prisma.ts
src/utils/recalculateCriteriaScore.ts
src/utils/db/calculatedGoalsFields.ts
src/utils/db/createComment.ts
src/utils/db/index.ts
src/utils/worker/goalPingJob.ts
src/utils/worker/index.ts
trpc/queries/access.ts
trpc/queries/goals.ts
trpc/queries/project.ts
trpc/router/goal.ts
trpc/router/project.ts
trpc/router/tag.ts
trpc/router/user.ts
src/components/FlowComboBox.tsx
src/components/GoalCommentCreateForm.tsx
src/components/GoalDependencyList.tsx
src/components/GoalList.tsx
src/components/GoalListItemCompact.tsx
src/components/GoalSuggest.tsx
src/components/PresetDropdown.tsx
src/components/StateDropdown.tsx
src/components/StateFilter.tsx
src/components/StateSwitch.tsx
src/components/CommentCreateForm/CommentCreateForm.tsx
src/components/GoalDependency/GoalDependency.tsx
src/components/GoalForm/GoalForm.tsx
src/components/HistoryRecord/HistoryRecord.tsx
src/components/UserEditableList/UserEditableList.tsx
```

## PR includes

- [x] DX

## Related issues

Resolve #1686 
