### PR TITLE
Radio button should be checked when criteria is done

### DIFF
--- a/src/components/NewGoalCriteria/NewGoalCriteria.tsx
+++ b/src/components/NewGoalCriteria/NewGoalCriteria.tsx
@@ -28,7 +28,7 @@ const SimpleCriteria: React.FC<Omit<CriteriaProps, 'id'>> = ({ title, isDone, we
         <TableCell width={350}>
             <Checkbox
                 className={classes.NewGoalCriteriaItemCheckbox}
-                defaultChecked={isDone}
+                checked={isDone}
                 readOnly
                 view="rounded"
                 label={


### PR DESCRIPTION
The `defaultChecked` prop is only used during initial render

## PR includes

- [x] Bug Fix

## Related issues

Resolve #2381 

## QA Instructions, Screenshots, Recordings
  
<img width="484" alt="Снимок экрана 2024-02-26 в 14 58 19" src="https://github.com/taskany-inc/issues/assets/95316053/5310f1da-d903-4cb4-bdd0-478562711671">
