### PR TITLE
Goal selection waits for the preview to load

### DIFF
--- a/src/components/DashboardPage/DashboardPage.tsx
+++ b/src/components/DashboardPage/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { ListView, nullable } from '@taskany/bricks';
 import { TreeViewElement } from '@taskany/bricks/harmony';
 
@@ -61,7 +61,7 @@ export const DashboardPage = ({ user, ssrTime, defaultPresetFallback }: External
 
     useFMPMetric(!!data);
 
-    const { setPreview, preview, on } = useGoalPreview();
+    const { setPreview, on } = useGoalPreview();
 
     useEffect(() => {
         const unsubUpdate = on('on:goal:update', () => {
@@ -77,23 +77,6 @@ export const DashboardPage = ({ user, ssrTime, defaultPresetFallback }: External
             unsubDelete();
         };
     }, [on, utils.project.getUserProjectsWithGoals]);
-
-    useEffect(() => {
-        const isGoalDeletedAlready = preview && !goals?.some((g) => g.id === preview.id);
-
-        if (isGoalDeletedAlready) setPreview(null);
-    }, [goals, preview, setPreview]);
-
-    const onGoalPreviewShow = useCallback(
-        (goal: Parameters<typeof setPreview>[1]): MouseEventHandler<HTMLAnchorElement> =>
-            (e) => {
-                if (e.metaKey || e.ctrlKey || !goal?._shortId) return;
-
-                e.preventDefault();
-                setPreview(goal._shortId, goal);
-            },
-        [setPreview],
-    );
 
     const onFilterStar = useCallback(async () => {
         await utils.filter.getById.invalidate();
@@ -147,7 +130,7 @@ export const DashboardPage = ({ user, ssrTime, defaultPresetFallback }: External
                             href={routes.project(project.id)}
                             goals={nullable(goals, (g) => (
                                 <TreeViewElement>
-                                    <GoalTableList goals={g} onGoalPreviewShow={onGoalPreviewShow} />
+                                    <GoalTableList goals={g} />
                                 </TreeViewElement>
                             ))}
                         >

--- a/src/components/DashboardPage/DashboardPage.tsx
+++ b/src/components/DashboardPage/DashboardPage.tsx
@@ -95,8 +95,6 @@ export const DashboardPage = ({ user, ssrTime, defaultPresetFallback }: External
         [setPreview],
     );
 
-    const selectedGoalResolver = useCallback((id: string) => id === preview?.id, [preview]);
-
     const onFilterStar = useCallback(async () => {
         await utils.filter.getById.invalidate();
     }, [utils]);
@@ -149,11 +147,7 @@ export const DashboardPage = ({ user, ssrTime, defaultPresetFallback }: External
                             href={routes.project(project.id)}
                             goals={nullable(goals, (g) => (
                                 <TreeViewElement>
-                                    <GoalTableList
-                                        goals={g}
-                                        selectedGoalResolver={selectedGoalResolver}
-                                        onGoalPreviewShow={onGoalPreviewShow}
-                                    />
+                                    <GoalTableList goals={g} onGoalPreviewShow={onGoalPreviewShow} />
                                 </TreeViewElement>
                             ))}
                         >

--- a/src/components/FlatGoalList.tsx
+++ b/src/components/FlatGoalList.tsx
@@ -65,8 +65,6 @@ export const FlatGoalList: React.FC<GoalListProps> = ({ queryState, onTagClick }
         if (isGoalDeletedAlready) setPreview(null);
     }, [goalsOnScreen, preview, setPreview]);
 
-    const selectedGoalResolver = useCallback((id: string) => id === preview?.id, [preview]);
-
     const onGoalPreviewShow = useCallback(
         (goal: Parameters<typeof setPreview>[1]): MouseEventHandler<HTMLAnchorElement> =>
             (e) => {
@@ -88,12 +86,7 @@ export const FlatGoalList: React.FC<GoalListProps> = ({ queryState, onTagClick }
     return (
         <ListView onKeyboardClick={handleItemEnter}>
             {nullable(goalsOnScreen, (goals) => (
-                <GoalTableList
-                    goals={goals}
-                    onTagClick={onTagClick}
-                    selectedGoalResolver={selectedGoalResolver}
-                    onGoalPreviewShow={onGoalPreviewShow}
-                />
+                <GoalTableList goals={goals} onTagClick={onTagClick} onGoalPreviewShow={onGoalPreviewShow} />
             ))}
 
             {nullable(hasNextPage, () => (

--- a/src/components/FlatGoalList.tsx
+++ b/src/components/FlatGoalList.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, MouseEventHandler, useCallback, useEffect, useMemo, useState } from 'react';
+import { ComponentProps, useCallback, useEffect, useMemo, useState } from 'react';
 import { ListView, nullable } from '@taskany/bricks';
 
 import { QueryState } from '../hooks/useUrlFilterParams';
@@ -20,7 +20,7 @@ const pageSize = 20;
 
 export const FlatGoalList: React.FC<GoalListProps> = ({ queryState, onTagClick }) => {
     const utils = trpc.useContext();
-    const { preview, setPreview, on } = useGoalPreview();
+    const { setPreview, on } = useGoalPreview();
 
     const [, setPage] = useState(0);
     const { data, fetchNextPage, hasNextPage } = trpc.goal.getBatch.useInfiniteQuery(
@@ -59,23 +59,6 @@ export const FlatGoalList: React.FC<GoalListProps> = ({ queryState, onTagClick }
         setPage((prev) => prev++);
     }, [fetchNextPage]);
 
-    useEffect(() => {
-        const isGoalDeletedAlready = preview && !goalsOnScreen?.some((g) => g.id === preview.id);
-
-        if (isGoalDeletedAlready) setPreview(null);
-    }, [goalsOnScreen, preview, setPreview]);
-
-    const onGoalPreviewShow = useCallback(
-        (goal: Parameters<typeof setPreview>[1]): MouseEventHandler<HTMLAnchorElement> =>
-            (e) => {
-                if (e.metaKey || e.ctrlKey || !goal?._shortId) return;
-
-                e.preventDefault();
-                setPreview(goal._shortId, goal);
-            },
-        [setPreview],
-    );
-
     const handleItemEnter = useCallback(
         (goal: NonNullable<GoalByIdReturnType>) => {
             setPreview(goal._shortId, goal);
@@ -86,7 +69,7 @@ export const FlatGoalList: React.FC<GoalListProps> = ({ queryState, onTagClick }
     return (
         <ListView onKeyboardClick={handleItemEnter}>
             {nullable(goalsOnScreen, (goals) => (
-                <GoalTableList goals={goals} onTagClick={onTagClick} onGoalPreviewShow={onGoalPreviewShow} />
+                <GoalTableList goals={goals} onTagClick={onTagClick} />
             ))}
 
             {nullable(hasNextPage, () => (

--- a/src/components/GoalTableList/GoalTableList.tsx
+++ b/src/components/GoalTableList/GoalTableList.tsx
@@ -15,24 +15,24 @@ import { routes } from '../../hooks/router';
 import { TagsList } from '../TagsList/TagsList';
 import { RelativeTime } from '../RelativeTime/RelativeTime';
 import { GoalCriteriaPreview } from '../NewGoalCriteria/NewGoalCriteria';
+import { useGoalPreview } from '../GoalPreview/GoalPreviewProvider';
 
 import s from './GoalTableList.module.css';
 
 interface GoalTableListProps<T> {
     goals: T[];
-    selectedGoalResolver?: (id: string) => boolean;
     onGoalPreviewShow: (goal: T) => MouseEventHandler<HTMLAnchorElement>;
     onTagClick?: (tag: { id: string }) => MouseEventHandler<HTMLDivElement>;
 }
 
 export const GoalTableList = <T extends Partial<NonNullable<GoalByIdReturnType>>>({
     goals,
-    selectedGoalResolver,
     onGoalPreviewShow,
     onTagClick,
     ...attrs
 }: GoalTableListProps<T>) => {
     const locale = useLocale();
+    const { shortId, preview } = useGoalPreview();
 
     const data = useMemo(
         () =>
@@ -145,7 +145,7 @@ export const GoalTableList = <T extends Partial<NonNullable<GoalByIdReturnType>>
                         value={row.goal}
                         renderItem={({ active, hovered: _, ...props }) => (
                             <TableListItem
-                                selected={selectedGoalResolver?.(row.goal?.id as string)}
+                                selected={row.goal._shortId === shortId || row.goal.id === preview?.id}
                                 hovered={active}
                                 {...props}
                             >

--- a/src/components/GroupedGoalList.tsx
+++ b/src/components/GroupedGoalList.tsx
@@ -19,7 +19,7 @@ interface GroupedGoalListProps {
 export const projectsSize = 20;
 
 export const GroupedGoalList: React.FC<GroupedGoalListProps> = ({ queryState, onTagClick }) => {
-    const { preview, setPreview, on } = useGoalPreview();
+    const { setPreview, on } = useGoalPreview();
     const utils = trpc.useContext();
     const { data, fetchNextPage, hasNextPage } = trpc.project.getAll.useInfiniteQuery(
         {
@@ -62,8 +62,6 @@ export const GroupedGoalList: React.FC<GroupedGoalListProps> = ({ queryState, on
         [setPreview],
     );
 
-    const selectedGoalResolver = useCallback((id: string) => id === preview?.id, [preview]);
-
     const projectsOnScreen = useMemo(() => {
         const pages = data?.pages || [];
 
@@ -84,7 +82,6 @@ export const GroupedGoalList: React.FC<GroupedGoalListProps> = ({ queryState, on
                     key={project.id}
                     project={project}
                     onClickProvider={onGoalPreviewShow}
-                    selectedResolver={selectedGoalResolver}
                     queryState={queryState}
                     onTagClick={onTagClick}
                 />

--- a/src/components/GroupedGoalList.tsx
+++ b/src/components/GroupedGoalList.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, MouseEventHandler, useCallback, useEffect, useMemo } from 'react';
+import { ComponentProps, useCallback, useEffect, useMemo } from 'react';
 import { ListView, nullable } from '@taskany/bricks';
 
 import { QueryState } from '../hooks/useUrlFilterParams';
@@ -51,17 +51,6 @@ export const GroupedGoalList: React.FC<GroupedGoalListProps> = ({ queryState, on
 
     useFMPMetric(!!data);
 
-    const onGoalPreviewShow = useCallback(
-        (goal: Parameters<typeof setPreview>[1]): MouseEventHandler<HTMLAnchorElement> =>
-            (e) => {
-                if (e.metaKey || e.ctrlKey || !goal?._shortId) return;
-
-                e.preventDefault();
-                setPreview(goal._shortId, goal);
-            },
-        [setPreview],
-    );
-
     const projectsOnScreen = useMemo(() => {
         const pages = data?.pages || [];
 
@@ -81,7 +70,6 @@ export const GroupedGoalList: React.FC<GroupedGoalListProps> = ({ queryState, on
                 <ProjectListItemConnected
                     key={project.id}
                     project={project}
-                    onClickProvider={onGoalPreviewShow}
                     queryState={queryState}
                     onTagClick={onTagClick}
                 />

--- a/src/components/ProjectListItemConnected.tsx
+++ b/src/components/ProjectListItemConnected.tsx
@@ -16,7 +16,6 @@ import { useGoalPreview } from './GoalPreview/GoalPreviewProvider';
 interface ProjectListItemConnectedProps extends ComponentProps<typeof ProjectListItemCollapsable> {
     queryState?: Partial<QueryState>;
     onClickProvider?: (g: Partial<GoalByIdReturnType>) => MouseEventHandler<HTMLElement>;
-    selectedResolver?: (id: string) => boolean;
     onTagClick?: ComponentProps<typeof GoalTableList>['onTagClick'];
 }
 
@@ -32,7 +31,6 @@ export const ProjectListItemConnected: FC<ProjectListItemConnectedProps> = ({
     queryState,
     project,
     onClickProvider,
-    selectedResolver,
     onTagClick,
     ...props
 }) => {
@@ -85,7 +83,6 @@ export const ProjectListItemConnected: FC<ProjectListItemConnectedProps> = ({
                     <GoalTableList
                         goals={goals}
                         onTagClick={onTagClick}
-                        selectedGoalResolver={selectedResolver}
                         onGoalPreviewShow={(goal) => (e) => {
                             onClickProvider?.(goal)(e);
                             onProjectClickHandler(e);
@@ -107,7 +104,6 @@ export const ProjectListItemConnected: FC<ProjectListItemConnectedProps> = ({
                     project={p}
                     queryState={queryState}
                     onClickProvider={onClickProvider}
-                    selectedResolver={selectedResolver}
                     titleSize="m"
                 />
             ))}

--- a/src/components/ProjectListItemConnected.tsx
+++ b/src/components/ProjectListItemConnected.tsx
@@ -30,7 +30,6 @@ const onProjectClickHandler = (e: React.MouseEvent) => {
 export const ProjectListItemConnected: FC<ProjectListItemConnectedProps> = ({
     queryState,
     project,
-    onClickProvider,
     onTagClick,
     ...props
 }) => {
@@ -80,14 +79,7 @@ export const ProjectListItemConnected: FC<ProjectListItemConnectedProps> = ({
             project={project}
             goals={nullable(projectDeepInfo?.goals, (goals) => (
                 <TreeViewElement>
-                    <GoalTableList
-                        goals={goals}
-                        onTagClick={onTagClick}
-                        onGoalPreviewShow={(goal) => (e) => {
-                            onClickProvider?.(goal)(e);
-                            onProjectClickHandler(e);
-                        }}
-                    />
+                    <GoalTableList goals={goals} onTagClick={onTagClick} onGoalClick={onProjectClickHandler} />
                 </TreeViewElement>
             ))}
             {...props}
@@ -99,13 +91,7 @@ export const ProjectListItemConnected: FC<ProjectListItemConnectedProps> = ({
                 )}
             </TreeViewElement>
             {childrenProjects.map((p) => (
-                <ProjectListItemConnected
-                    key={p.id}
-                    project={p}
-                    queryState={queryState}
-                    onClickProvider={onClickProvider}
-                    titleSize="m"
-                />
+                <ProjectListItemConnected key={p.id} project={p} queryState={queryState} titleSize="m" />
             ))}
         </ProjectListItemCollapsable>
     );

--- a/src/components/ProjectPage/ProjectPage.tsx
+++ b/src/components/ProjectPage/ProjectPage.tsx
@@ -57,7 +57,7 @@ export const ProjectPage = ({ user, ssrTime, params: { id }, defaultPresetFallba
         },
     );
 
-    const { preview, setPreview, on } = useGoalPreview();
+    const { setPreview, on } = useGoalPreview();
 
     useEffect(() => {
         const unsubUpdate = on('on:goal:update', () => {
@@ -85,8 +85,6 @@ export const ProjectPage = ({ user, ssrTime, params: { id }, defaultPresetFallba
             },
         [setPreview],
     );
-
-    const selectedGoalResolver = useCallback((id: string) => id === preview?.id, [preview]);
 
     useEffect(() => {
         if (!project || project.personal) return;
@@ -177,7 +175,6 @@ export const ProjectPage = ({ user, ssrTime, params: { id }, defaultPresetFallba
                             project={p}
                             onTagClick={setTagsFilterOutside}
                             onClickProvider={onGoalPreviewShow}
-                            selectedResolver={selectedGoalResolver}
                             queryState={queryState}
                         />
                     ))}

--- a/src/components/ProjectPage/ProjectPage.tsx
+++ b/src/components/ProjectPage/ProjectPage.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { ListView, nullable } from '@taskany/bricks';
 
 import { Page } from '../Page/Page';
@@ -74,17 +74,6 @@ export const ProjectPage = ({ user, ssrTime, params: { id }, defaultPresetFallba
             unsubDelete();
         };
     }, [on, utils.project.getDeepInfo, utils.project.getById]);
-
-    const onGoalPreviewShow = useCallback(
-        (goal: Parameters<typeof setPreview>[1]): MouseEventHandler<HTMLAnchorElement> =>
-            (e) => {
-                if (e.metaKey || e.ctrlKey || !goal?._shortId) return;
-
-                e.preventDefault();
-                setPreview(goal._shortId, goal);
-            },
-        [setPreview],
-    );
 
     useEffect(() => {
         if (!project || project.personal) return;
@@ -174,7 +163,6 @@ export const ProjectPage = ({ user, ssrTime, params: { id }, defaultPresetFallba
                             visible
                             project={p}
                             onTagClick={setTagsFilterOutside}
-                            onClickProvider={onGoalPreviewShow}
                             queryState={queryState}
                         />
                     ))}


### PR DESCRIPTION
Now the comparison will be performed by selecteted `_shortId` before receiving the goal object in the context of the preview
Drop extra `selectGoalResolver` move marking logic inside `<GoalTableList />` component

Also move preview click handler inside `<GoalTableList /> component

## PR includes

- [x] Bug Fix

## Related issues

Resolve #2316 

## QA Instructions, Screenshots, Recordings
  
https://github.com/taskany-inc/issues/assets/7002692/a67bbb52-f614-4369-8c34-65b8c4193bcf

Example with network throttling (fast 3G)

