### PR TITLE
Create one more goal resets options

### DIFF
--- a/src/components/GoalCreateForm/GoalCreateForm.tsx
+++ b/src/components/GoalCreateForm/GoalCreateForm.tsx
@@ -29,17 +29,12 @@ import { tr } from './GoalCreateForm.i18n';
 import s from './GoalCreateForm.module.css';
 
 interface GoalCreateFormProps {
-    project?: {
-        id: string;
-        title: string;
-        flowId: string;
-    };
     title?: string;
     onGoalCreate?: (val: GoalCreateReturnType) => void;
     personal?: boolean;
 }
 
-const GoalCreateForm: React.FC<GoalCreateFormProps> = ({ title, onGoalCreate, project, personal }) => {
+const GoalCreateForm: React.FC<GoalCreateFormProps> = ({ title, onGoalCreate, personal }) => {
     const router = useRouter();
     const { user } = usePageContext();
     const [lastProjectCache, setLastProjectCache] = useLocalStorage('lastProjectCache');
@@ -100,14 +95,11 @@ const GoalCreateForm: React.FC<GoalCreateFormProps> = ({ title, onGoalCreate, pr
 
         if (form.parent) {
             const newRecentProjectsCache = { ...recentProjectsCache };
-            if (newRecentProjectsCache[form.parent.id]) {
-                newRecentProjectsCache[form.parent.id].rate += 1;
-            } else {
-                newRecentProjectsCache[form.parent.id] = {
-                    rate: 1,
-                    cache: form.parent,
-                };
-            }
+            newRecentProjectsCache[form.parent.id] = {
+                rate: Date.now(),
+                cache: form.parent,
+            };
+
             setRecentProjectsCache(newRecentProjectsCache);
             setLastProjectCache(form.parent);
 
@@ -146,7 +138,7 @@ const GoalCreateForm: React.FC<GoalCreateFormProps> = ({ title, onGoalCreate, pr
             busy={busy}
             validitySchema={goalCommonSchema}
             owner={{ id: user?.activityId, user } as ActivityByIdReturnType}
-            parent={project || currentProjectCache || lastProjectCache || undefined}
+            parent={currentProjectCache || lastProjectCache || undefined}
             personal={personal}
             priority={defaultPriority ?? undefined}
             onSubmit={createGoal}

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -19,6 +19,7 @@ import { ModalContext } from '../ModalOnEvent';
 import { useGoalPreview } from '../GoalPreview/GoalPreviewProvider';
 import { PageNavigation } from '../PageNavigation/PageNavigation';
 import { pageContent } from '../../utils/domObjects';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
 
 import s from './Page.module.css';
 
@@ -49,14 +50,23 @@ export const Page: React.FC<PageProps> = ({ user, ssrTime, title = 'Untitled', c
     const { data: userSettings = user?.settings } = trpc.user.settings.useQuery();
     const { data: config } = trpc.appConfig.get.useQuery();
 
+    const router = useRouter();
+
+    const [_, setCurrentProject] = useLocalStorage('currentProjectCache');
+    useEffect(() => {
+        const { asPath } = router;
+
+        if (!asPath.includes('/projects/')) {
+            setCurrentProject(null);
+        }
+    }, [router, setCurrentProject]);
+
     useHotkeys();
 
     const { resolvedTheme } = useTheme();
     const theme = (
         userSettings?.theme === 'system' ? resolvedTheme || 'dark' : userSettings?.theme || 'light'
     ) as PageContext['theme'];
-
-    const router = useRouter();
 
     useEffect(() => {
         setPreview(null);

--- a/src/hooks/useWillUnmount.ts
+++ b/src/hooks/useWillUnmount.ts
@@ -11,10 +11,20 @@ export function useWillUnmount(callback?: any) {
         mountRef.current = true;
         const { current: currentHandler } = handler;
 
+        const handleUnmount = () => {
+            if (currentHandler && mountRef.current) {
+                currentHandler();
+            }
+        };
+
+        window.addEventListener('beforeunload', handleUnmount);
+
         return () => {
             if (currentHandler && mountRef.current) {
                 currentHandler();
             }
+
+            window.removeEventListener('beforeunload', handleUnmount);
         };
     }, [handler]);
 


### PR DESCRIPTION
Fixed sorting by last usage project
Added clear current project from LS by unload event if user close tab the project's page
Also added clear current project on any page exclude project's page

## PR includes

- [x] Bug Fix

## Related issues

Resolve #2507 
