### PR TITLE
Fix calculate goals count in Dashboard page

### DIFF
--- a/src/components/DashboardPage/DashboardPage.tsx
+++ b/src/components/DashboardPage/DashboardPage.tsx
@@ -55,7 +55,7 @@ export const DashboardPage = ({ user, ssrTime, defaultPresetFallback }: External
         return [
             gr,
             gr.reduce((acc, group) => acc + group._count.goals, 0),
-            pages?.[pages.length - 1].totalGoalsCount ?? 0,
+            pages.reduce((acc, { totalGoalsCount = 0 }) => acc + Number(totalGoalsCount), 0),
         ];
     }, [pages]);
 


### PR DESCRIPTION
Fix goals counter in Dashboard
Now, overall goals count increasing by load next page of Dashboard including showed goals by applying filters

## PR includes

- [x] Bug Fix

## Related issues

Resolve #2745 

Related issues #2653 