### PR TITLE
Filter by strict date doesn't works in Dashboard

### DIFF
--- a/trpc/queries/projectV2.ts
+++ b/trpc/queries/projectV2.ts
@@ -395,7 +395,7 @@ export const getUserProjectsWithGoals = (params: GetProjectsWithGoalsByIdsParams
                             // eslint-disable-next-line no-nested-ternary
                             estimate.length > 0
                                 ? estimate.length === 1
-                                    ? eb('Goal.estimate', 'in', val<Date>(estimate[0]))
+                                    ? eb('Goal.estimate', '=', val<Date>(estimate[0]))
                                     : and([
                                           eb('Goal.estimate', '>=', val<Date>(estimate[0])),
                                           eb('Goal.estimate', '<=', val<Date>(estimate[1])),


### PR DESCRIPTION
Now it works

## PR includes

- [x] Bug Fix

## Related issues

Resolve #2752
